### PR TITLE
Add colors to indent highlights (optionally)

### DIFF
--- a/hl-indent.el
+++ b/hl-indent.el
@@ -371,6 +371,11 @@ following lines, otherwise scan all of the them."
     ;; (message "point %d:  %d,  %d:  \"%s\"" (point) (line-end-position) (1- (line-beginning-position 2)) (buffer-substring (point) (min (line-end-position) (+ 4 (point) (save-excursion (skip-syntax-forward " " (line-end-position)))))))
     (skip-syntax-forward " " (line-end-position))))
 
+(defun hl-indent--face-for-level (level)
+  (intern (format "hl-indent-block-face-%s"
+                  (1+ (mod (cl-position level (reverse hl-indent--current-indent))
+                           (length hl-indent--current-indent))))))
+
 (defun hl-indent--scan-line (&optional stop-soon)
   "Highlight indentation levels on the current line.
 The variable `hl-indent--current-indent' will contain indentation levels
@@ -391,7 +396,7 @@ correctly on the next line."
         (setq hl-indent--current-indent (cdr hl-indent--current-indent)))
       (dolist (level hl-indent--current-indent)
         (let* ((pos (+ line-start level))
-               (o (hl-indent--make-overlay pos (1+ pos) 'hl-indent-face)))
+               (o (hl-indent--make-overlay pos (1+ pos) (hl-indent--face-for-level level))))
           (when hl-indent-mode-blocks
             (overlay-put o 'face nil))))
       (when (and hl-indent-mode-blocks

--- a/hl-indent.el
+++ b/hl-indent.el
@@ -225,6 +225,12 @@ looks bad."
   :type 'boolean
   :group 'hl-indent)
 
+(defcustom hl-indent-color-indents
+  nil
+  "Whether indent highlights should be colored or not."
+  :type 'boolean
+  :group 'hl-indent)
+
 ;; }}}
 ;; {{{ Overlay handling
 
@@ -396,7 +402,10 @@ correctly on the next line."
         (setq hl-indent--current-indent (cdr hl-indent--current-indent)))
       (dolist (level hl-indent--current-indent)
         (let* ((pos (+ line-start level))
-               (o (hl-indent--make-overlay pos (1+ pos) (hl-indent--face-for-level level))))
+               (face (if hl-indent-color-indents
+                         (hl-indent--face-for-level level)
+                       'hl-indent-face))
+               (o (hl-indent--make-overlay pos (1+ pos) face)))
           (when hl-indent-mode-blocks
             (overlay-put o 'face nil))))
       (when (and hl-indent-mode-blocks


### PR DESCRIPTION
Hi there,

This package is pretty neat for languages like Python and Yaml, but especially in Yaml I feel that a lot of singularly-colored bars to the right still don't make it very clear where a certain block ends or begins. It doesn't help that the most Yaml I work with at the moment is big Rails translation files either.

Adding colors in to the mix really helped me make things a bit clearer.

I thought I'd set the default value for the defcustom to nil so that people don't have to change a setting to get back to the functionality they're used to.

Please let me know what you think. And thanks for this excellent package.
